### PR TITLE
Fixes 27/08/2023

### DIFF
--- a/AppGCT/Pages/Gestao/Movimentos/Index.cshtml
+++ b/AppGCT/Pages/Gestao/Movimentos/Index.cshtml
@@ -75,6 +75,9 @@
             <div class="form-group d-inline-block">
                 <select asp-for="IdGinasta" class="form-control" asp-items="@Model.GinastasList"></select>
             </div>
+            <div class="form-group d-inline-block">
+                <input type="date" class="form-control"  name="SearchString" value="@Model.CurrentFilter" />
+            </div>
             <input type="submit" value="Procurar" class="btn btn-primary btn-sm" />
             <a class="btn btn-primary btn-sm" asp-area="" asp-page="/Gestao/Movimentos/Index">Limpar</a>
         </p>

--- a/AppGCT/Pages/Gestao/Movimentos/Index.cshtml.cs
+++ b/AppGCT/Pages/Gestao/Movimentos/Index.cshtml.cs
@@ -32,17 +32,30 @@ namespace AppGCT.Pages.Gestao.Movimentos
         public string IdSocio { get; set; }
         [BindProperty(SupportsGet = true)]
         public int IdGinasta { get; set; }
+        public string CurrentFilter { get; set; }
         public IList<Movimento> Movimento { get;set; } = default!;
 
         public SelectList SociosList { get; set; }
         public SelectList GinastasList { get; set; }
 
-        public async Task OnGetAsync(string? idsocio, int? idginasta)
+        public async Task OnGetAsync(string? idsocio, int? idginasta, string searchString)
         {
-            if (idsocio != null || idginasta.HasValue)
+            DateTime searchDate;
+
+            if (idsocio != null || idginasta.HasValue || (!string.IsNullOrEmpty(searchString)))
             {
                 IdSocio = idsocio;
                 IdGinasta = idginasta.Value;
+                CurrentFilter = searchString;
+            }
+
+            if (!string.IsNullOrEmpty(searchString))
+            {
+                searchDate = DateTime.Parse(searchString);
+            }
+            else
+            {
+                searchDate = DateTime.MinValue;
             }
             
             string userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
@@ -121,7 +134,7 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                     .Include(m => m.FormaPagamento)
                                     .Include(m => m.Socio)
                                     .Include(m => m.TipoDespesa)
-                                    .Where(m => m.UtilizadorId == idsocio && m.AtletaMovimentoId == idginasta)
+                                    .Where(m => m.UtilizadorId == idsocio && m.AtletaMovimentoId == idginasta && m.DtMovimento >= searchDate)
                                     .OrderByDescending(m => m.DataCriacao)
                                     .ToListAsync();
                     }
@@ -134,7 +147,7 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                     .Include(m => m.FormaPagamento)
                                     .Include(m => m.Socio)
                                     .Include(m => m.TipoDespesa)
-                                    .Where(m => m.UtilizadorId == idsocio)
+                                    .Where(m => m.UtilizadorId == idsocio && m.DtMovimento >= searchDate)
                                     .OrderByDescending(m => m.DataCriacao)
                                     .ToListAsync();
                     }
@@ -147,7 +160,7 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                     .Include(m => m.FormaPagamento)
                                     .Include(m => m.Socio)
                                     .Include(m => m.TipoDespesa)
-                                    .Where(m => m.AtletaMovimentoId == idginasta)
+                                    .Where(m => m.AtletaMovimentoId == idginasta && m.DtMovimento >= searchDate)
                                     .OrderByDescending(m => m.DataCriacao)
                                     .ToListAsync();
                     }
@@ -158,6 +171,7 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                     .Include(m => m.FormaPagamento)
                                     .Include(m => m.Socio)
                                     .Include(m => m.TipoDespesa)
+                                    .Where(m => m.DtMovimento >= searchDate)
                                     .OrderByDescending(m => m.DataCriacao)
                                     .ToListAsync();
                     }
@@ -170,7 +184,7 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                    .Include(m => m.Atleta)
                                    .Include(m => m.FormaPagamento)
                                    .Include(m => m.Socio)
-                                   .Include(m => m.TipoDespesa).Where(m => m.UtilizadorId.Equals(userId) && m.AtletaMovimentoId == idginasta)
+                                   .Include(m => m.TipoDespesa).Where(m => m.UtilizadorId.Equals(userId) && m.AtletaMovimentoId == idginasta && m.DtMovimento >= searchDate)
                                    .OrderByDescending(m => m.DataCriacao)
                                    .ToListAsync();
                     }
@@ -180,7 +194,8 @@ namespace AppGCT.Pages.Gestao.Movimentos
                                    .Include(m => m.Atleta)
                                    .Include(m => m.FormaPagamento)
                                    .Include(m => m.Socio)
-                                   .Include(m => m.TipoDespesa).Where(m => m.UtilizadorId.Equals(userId))
+                                   .Include(m => m.TipoDespesa)
+                                   .Where(m => m.UtilizadorId.Equals(userId) && m.DtMovimento >= searchDate)
                                    .OrderByDescending(m => m.DataCriacao)
                                    .ToListAsync();
                     }

--- a/AppGCT/Pages/Gestao/Utilizadores/Index.cshtml.cs
+++ b/AppGCT/Pages/Gestao/Utilizadores/Index.cshtml.cs
@@ -107,16 +107,12 @@ namespace AppGCT.Pages.Gestao.Utilizadores
                 case "nomecompleto_desc":
                     UserIQ = UserIQ.OrderByDescending(s => s.Nome);
                     break;
-                //case "TipoUtilizador":
-                //    var users = await UserIQ.ToListAsync();
-                //users = users.OrderBy(user => _userManager.GetRolesAsync(user).Result.FirstOrDefault()).ToList();
-                //Users = users;
-                //break;
-                //case "tipoutilizador_desc":
-                //var usersDesc = await UserIQ.ToListAsync();
-                //usersDesc = usersDesc.OrderByDescending(user => _userManager.GetRolesAsync(user).Result.FirstOrDefault()).ToList();
-                //Users = usersDesc;
-                //break;
+                case "TipoUtilizador":
+                    UserIQ = UserIQ.OrderBy(s => s.RoleAux);
+                    break;
+                case "tipoutilizador_desc":
+                    UserIQ = UserIQ.OrderByDescending(s => s.RoleAux);
+                    break;
                 case "NumSocio":
                     UserIQ = UserIQ.OrderBy(s => s.NumSocio);
                     break;

--- a/AppGCT/Pages/Inscricoes/InscricaoEpoca/Create.cshtml.cs
+++ b/AppGCT/Pages/Inscricoes/InscricaoEpoca/Create.cshtml.cs
@@ -156,6 +156,12 @@ namespace AppGCT.Pages.Inscricoes.InscricaoEpoca
                 DateTime dataMensalidade = epoca.DataInicio.AddMonths(i);
                 if (dataMensalidade.Month == dtInscricao.Month || dataMensalidade > dtInscricao)
                 {
+                    //se for o último mês da época não cobra e coloca o valor da mensalidade a 0
+                    if (dataMensalidade.Month == epoca.DataFim.Month)
+                    {
+                        valorMensalidade = 0;
+                    }
+                    //cria plano
                     var planoMensalidade = new PlanoMensalidade
                     {
                         DataMensalidade = dataMensalidade,


### PR DESCRIPTION
-Inclusão de validação no Create da InscricaoEpoca para que o último mês da Época tenha valor zero pois é de graça segundo o GCT;
-Inclusão de validação no Edit da InscricaoEpoca para que o último mês da Época tenha valor zero pois é de graça segundo o GCT (quando haja atualizações de plano);
-Inclusão de validação no Edit da InscricaoEpoca para que quando haja atualizações de plano e a data da mensalidade seja inferior ou igual à do dia e o ILANCADO != "S" e dtmensalidade(mês) = data dia (mês) então atualizamos esses planos (não vamos atualizar planos que já deviam ter sido lançados em meses anteriores).
-Correção no Index dos Utilizadores para corrigir o sort sobre o tipo de utilizador;
-Inclusão de filtro por data no Index dos Movimentos (o campo serve para apanhar movimentos com data superior ou igual à inserida);